### PR TITLE
Build gpii/universal Docker container using Ansible

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,11 @@
-FROM inclusivedesign/nodejs:0.10.33
+FROM inclusivedesign/nodejs:0.10.36
 
-RUN yum -y install git && \
-    yum clean all
+WORKDIR /etc/ansible/playbooks
 
-RUN mkdir -p /opt/universal
+COPY ansible/* /etc/ansible/playbooks/
 
-# Reduce the number of times 'npm install' is run by copying package.json
-# first and the remaining repository contents later
-COPY universal/package.json /opt/universal/
+RUN ansible-playbook build.yml --tags "configure"
 
-WORKDIR /opt/universal
-
-RUN npm install
-
-COPY universal/. /opt/universal/
-
-RUN npm -g install grunt-cli && \
-    grunt dedupe-infusion
+CMD ["/bin/bash"]
 
 CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,3 @@ COPY ansible/* /etc/ansible/playbooks/
 RUN ansible-playbook build.yml --tags "configure"
 
 CMD ["/bin/bash"]
-
-CMD ["/bin/bash"]

--- a/README.md
+++ b/README.md
@@ -3,16 +3,14 @@
 
 This repository is used to build GPII Universal Docker images. It can be used to help deploy GPII components such as the Preferences Server and Flow Manager.
 
-In order to build an image the Universal repository working directory should exist wherever the contents of this directory are saved. For transparent image versioning that maps directly to the official Git repository each new image should be tagged using the repository's short commit hash. For example:
+To build a specific branch, update the `nodejs_app_git_branch` variable in ansible/build-vars.yml with a branch name or similar
 
-    git clone https://github.com/gpii/universal
-    docker build --rm -t gpii/universal:$(git --git-dir=universal/.git --work-tree=universal rev-parse --short HEAD) .
+For transparent image versioning that maps directly to the official Git repository each new image should be tagged using the repository's short commit hash.
 
 
 ### Base Docker Image
 
 * [inclusivedesign/nodejs](https://registry.hub.docker.com/u/inclusivedesign/nodejs/)
-
 
 ### Download using either of the following commands:
 

--- a/ansible/build-vars.yml
+++ b/ansible/build-vars.yml
@@ -2,8 +2,6 @@ nodejs_app_name: universal
 nodejs_app_install_dir: /opt/{{ nodejs_app_name }}
 nodejs_app_git_repo: https://github.com/gpii/universal.git
 nodejs_app_git_branch: master
-nodejs_app_npm_packages:
-  - grunt-cli
 nodejs_app_commands:
   - npm install
   - grunt dedupe-infusion

--- a/ansible/build-vars.yml
+++ b/ansible/build-vars.yml
@@ -1,7 +1,8 @@
 nodejs_app_name: universal
-nodejs_app_install_dir: /opt/{{ nodejs_app_name }}
+nodejs_app_install_dir: /opt/gpii/node_modules/{{ nodejs_app_name }}
 nodejs_app_git_repo: https://github.com/gpii/universal.git
 nodejs_app_git_branch: master
 nodejs_app_commands:
   - npm install
   - grunt dedupe-infusion
+  - npm test

--- a/ansible/build-vars.yml
+++ b/ansible/build-vars.yml
@@ -1,0 +1,9 @@
+nodejs_app_name: universal
+nodejs_app_install_dir: /opt/{{ nodejs_app_name }}
+nodejs_app_git_repo: https://github.com/gpii/universal.git
+nodejs_app_git_branch: master
+nodejs_app_npm_packages:
+  - grunt-cli
+nodejs_app_commands:
+  - npm install
+  - grunt dedupe-infusion

--- a/ansible/build.yml
+++ b/ansible/build.yml
@@ -1,0 +1,8 @@
+---
+- hosts: local
+  connection: local
+  vars_files:
+  - build-vars.yml
+  roles:
+  - facts
+  - nodejs


### PR DESCRIPTION
@avtar / @gtirloni: I've tested this myself with several of the downstream containers (Preference Server and Flow Manager), but would appreciate testing and review by others.

It should (aside from the 0.10.33 > 0.10.36 node version change) built a functionally identical container to the existing Universal one.
